### PR TITLE
removed mock token and replaced with null

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
 		"": {
 			"name": "smart-shopping-list-next",
 			"dependencies": {
+				"@the-collab-lab/shopping-list-utils": "^2.0.0",
 				"firebase": "^9.17.2",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
@@ -3660,6 +3661,11 @@
 			"peerDependencies": {
 				"@testing-library/dom": ">=7.21.4"
 			}
+		},
+		"node_modules/@the-collab-lab/shopping-list-utils": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@the-collab-lab/shopping-list-utils/-/shopping-list-utils-2.0.0.tgz",
+			"integrity": "sha512-VHw1bfEoqroRpzle5PJLAqfsouhdFudihtRYVZcFbsPv/LVtAWcyEHXDjp1F/ixkXxY/+qyAjaT7XixsqiWOIQ=="
 		},
 		"node_modules/@tootallnate/once": {
 			"version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 		"npm": ">=8.19.0"
 	},
 	"dependencies": {
+		"@the-collab-lab/shopping-list-utils": "^2.0.0",
 		"firebase": "^9.17.2",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,7 +19,7 @@ export function App() {
 	 * to create and join a new list.
 	 */
 	const [listToken, setListToken] = useStateWithStorage(
-		'my test list',
+		null,
 		'tcl-shopping-list-token',
 	);
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -51,7 +51,10 @@ export function App() {
 		<Router>
 			<Routes>
 				<Route path="/" element={<Layout />}>
-					<Route index element={<Home setListToken={setListToken} />} />
+					<Route
+						index
+						element={<Home listToken={listToken} setListToken={setListToken} />}
+					/>
 					<Route path="/list" element={<List data={data} />} />
 					<Route path="/add-item" element={<AddItem />} />
 				</Route>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -51,7 +51,7 @@ export function App() {
 		<Router>
 			<Routes>
 				<Route path="/" element={<Layout />}>
-					<Route index element={<Home />} />
+					<Route index element={<Home setListToken={setListToken} />} />
 					<Route path="/list" element={<List data={data} />} />
 					<Route path="/add-item" element={<AddItem />} />
 				</Route>

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -1,4 +1,5 @@
 import './Home.css';
+import { generateToken } from '@the-collab-lab/shopping-list-utils';
 
 export function Home() {
 	return (
@@ -6,6 +7,7 @@ export function Home() {
 			<p>
 				Hello from the home (<code>/</code>) page!
 			</p>
+			<button>Create New List</button>
 		</div>
 	);
 }

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -1,14 +1,20 @@
 import './Home.css';
 import { generateToken } from '@the-collab-lab/shopping-list-utils';
 
-export function Home() {
+export function Home({ setListToken }) {
+	function handleClick() {
+		const token = generateToken();
+		setListToken(token);
+	}
+
 	return (
 		<div className="Home">
 			<p>
 				Hello from the home (<code>/</code>) page!
 			</p>
-			<button>Create New List</button>
-			<>{console.log(generateToken())}</>
+			<button type="button" onClick={handleClick}>
+				Create New List
+			</button>
 		</div>
 	);
 }

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -1,10 +1,15 @@
+import { Navigate } from 'react-router-dom';
 import './Home.css';
 import { generateToken } from '@the-collab-lab/shopping-list-utils';
+import * as React from 'react';
 
 export function Home({ setListToken }) {
+	const [clicked, setClicked] = React.useState(false);
+
 	function handleClick() {
 		const token = generateToken();
 		setListToken(token);
+		setClicked(true);
 	}
 
 	return (
@@ -15,6 +20,7 @@ export function Home({ setListToken }) {
 			<button type="button" onClick={handleClick}>
 				Create New List
 			</button>
+			{clicked && <Navigate to="/list" replace={true}></Navigate>}
 		</div>
 	);
 }

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -3,13 +3,16 @@ import './Home.css';
 import { generateToken } from '@the-collab-lab/shopping-list-utils';
 import * as React from 'react';
 
-export function Home({ setListToken }) {
-	const [clicked, setClicked] = React.useState(false);
+export function Home({ listToken, setListToken }) {
+	console.log(listToken); // prints 'undefined' even when a token exists in localStorage
+	const [tokenExists, setTokenExists] = React.useState(
+		listToken ? true : false,
+	);
 
 	function handleClick() {
 		const token = generateToken();
 		setListToken(token);
-		setClicked(true);
+		setTokenExists(true);
 	}
 
 	return (
@@ -20,7 +23,7 @@ export function Home({ setListToken }) {
 			<button type="button" onClick={handleClick}>
 				Create New List
 			</button>
-			{clicked && <Navigate to="/list" replace={true}></Navigate>}
+			{tokenExists && <Navigate to="/list" replace={true}></Navigate>}
 		</div>
 	);
 }

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -8,6 +8,7 @@ export function Home() {
 				Hello from the home (<code>/</code>) page!
 			</p>
 			<button>Create New List</button>
+			<>{console.log(generateToken())}</>
 		</div>
 	);
 }


### PR DESCRIPTION
_For an example of how to fill this template out, [see this Pull Request](https://github.com/the-collab-lab/tcl-3-smart-shopping-list/pull/44)._

## Description

<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? Reminder: This will be a publicly facing representation of your work (READ: help you land that sweet dev gig). -->
This PR removes default subscription to mock data and instead adds functionality to the application that allows the end user to either initiate a new shopping list or render their existing list if their browser is already associated with one.

To accomplish the above, a ternary operator was implemented at the `App.jsx` level to route the user home, (`/`), if a `listToken` does not exist or to the token’s associate `List` view, (`/list`), if a `listToken` already exists in their browser.

Should the user be redirected home, a button was implemented inside the `Home` component to allow them to initiate a new list. The button is connected to an `onClick` handler that generates a new token via the `generateToken` function from the `shopping-list-utils` package, saves the token to the browser’s `localStorage` via the `setListToken` utility function, and redirects the user to the token’s corresponding `List` view. And because of data persistence in `localStorage`, the end user is redirected to the `List` view associated with their unique token on any future browsing sessions.

## Related Issue
<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->
closes #3 

## Acceptance Criteria

<!-- Include AC from the Github issue -->

- [x] @the-collab-lab/shopping-list-utils is added as a dependency to the project.
- [x] The string my test list in App.jsx is replaced with null, so users are not automatically subscribed to any list.

If a user **doesn’t** already have a token:

- [x] A button in the Home component allows them to create a new list
- [x] Clicking the button generates a new token and saves it to localStorage using the setListToken function in App.jsx.
- [x] Once the token has been created and saved, the user is redirected to the List view.

If a user **does** already have a token:

- [x] They are automatically redirected to the List view.

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|  ✓    | :hammer: Refactoring       |
|     | :100: Add tests            |
|   ✓  | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

<img width="1431" alt="Screenshot 2023-04-11 at 11 30 03 AM" src="https://user-images.githubusercontent.com/98926845/231577292-b207ac56-8bca-4eb1-a787-ae75aba944b3.png">

Before our changes, the user was automatically subscribed to a test list associated with the `my test list` token.

### After

https://user-images.githubusercontent.com/98926845/231581313-0af604c0-a4e5-450b-90a2-667cdc495293.mov

After our changes, the user is not subscribed to a default test list, and is instead prompted to create a new list via the `Create New List` button on the home page. Once a user creates a list, a token is generated for that user and that token gets saved in local storage and the user is redirected to the list page. 
## Testing Steps / QA Criteria

Please view the deploy of our changes here: https://tcl-57-smart-shopping-list--pr17-jg-bm-token-generati-zv9skcnu.web.app/ and click on Home.  Open the Application Tab in your Dev tools, where you will see that  no token has yet been created. Click on the "Create List" Button, where you will be redirected to the List page, and see that a token has been generated in your Dev Tools.

