### PR TITLE
Mark items as purchased

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -66,7 +66,10 @@ export function App() {
 							)
 						}
 					/>
-					<Route path="/list" element={<List data={data} />} />
+					<Route
+						path="/list"
+						element={<List data={data} listToken={listToken} />}
+					/>
 					<Route path="/add-item" element={<AddItem listToken={listToken} />} />
 				</Route>
 			</Routes>

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -5,6 +5,7 @@ import {
 	getDocs,
 	updateDoc,
 	doc,
+	increment,
 } from 'firebase/firestore';
 import { db } from './config';
 import { getFutureDate } from '../utils';
@@ -86,6 +87,7 @@ export async function updateItem(listId, listItemId) {
 
 	await updateDoc(listItemRef, {
 		dateLastPurchased: new Date(),
+		totalPurchases: increment(1),
 	});
 }
 

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -8,7 +8,7 @@ import {
 	increment,
 } from 'firebase/firestore';
 import { db } from './config';
-import { getFutureDate } from '../utils';
+import { getFutureDate, ONE_DAY_IN_MILLISECONDS, CURRENT_DATE } from '../utils';
 
 /**
  * Subscribe to changes on a specific list in the Firestore database (listId), and run a callback (handleSuccess) every time a change happens.
@@ -58,16 +58,19 @@ export function getItemData(snapshot) {
 		 */
 		data.id = docRef.id;
 
+		/**
+		 * Add a new property to each item object in the data array called 'isDefaultChecked' whose value is set to true
+		 * if the item was checked less than 24 hours ago, and to false if 24 hours or more have elapsed. This property
+		 * will be used in the ListItem Component to control default status of the item's checkmark.
+		 */
 		let isDefaultChecked;
 
 		if (!data.dateLastPurchased) {
 			isDefaultChecked = false;
 		} else {
-			const dayInMilliseconds = 24 * 60 * 60 * 1000;
 			const date = data.dateLastPurchased.toDate();
-			const currentDate = new Date();
-			const timeElapsed = currentDate - date;
-			isDefaultChecked = timeElapsed < dayInMilliseconds;
+			const timeElapsed = CURRENT_DATE - date;
+			isDefaultChecked = timeElapsed < ONE_DAY_IN_MILLISECONDS;
 		}
 
 		data.isDefaultChecked = isDefaultChecked;
@@ -95,6 +98,12 @@ export async function addItem(listId, { itemName, daysUntilNextPurchase }) {
 		totalPurchases: 0,
 	});
 }
+
+/**
+ * Update the dateLastPurchased and the totalPurchases fields in Firestore for a specified item on user's list.
+ * @param {string} listId The id of the user's list
+ * @param {string} listItemId The id of the indiividual item
+ */
 
 export async function updateItem(listId, listItemId) {
 	const listItemRef = doc(db, listId, listItemId);

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -1,4 +1,10 @@
-import { addDoc, collection, onSnapshot, getDocs } from 'firebase/firestore';
+import {
+	addDoc,
+	collection,
+	onSnapshot,
+	getDocs,
+	getDoc,
+} from 'firebase/firestore';
 import { db } from './config';
 import { getFutureDate } from '../utils';
 
@@ -74,7 +80,18 @@ export async function addItem(listId, { itemName, daysUntilNextPurchase }) {
 	});
 }
 
-export async function updateItem() {
+export async function updateItem(listId, listItemId) {
+	//FIRESTORE SAMPLE
+
+	const listItemRef = collection(db, listId, listItemId);
+	const listItemSnapShot = await getDoc(listItemRef);
+	const result = await listItemSnapShot.update({
+		dateLastPurchased: new Date(),
+	});
+
+	// db.collection(listId).doc(listItemId);
+	// const res = await listItemRef.update({dateLastPurchased: new Date()});
+
 	/**
 	 * TODO: Fill this out so that it uses the correct Firestore function
 	 * to update an existing item. You'll need to figure out what arguments

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -3,7 +3,6 @@ import {
 	collection,
 	onSnapshot,
 	getDocs,
-	getDoc,
 	updateDoc,
 	doc,
 } from 'firebase/firestore';

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -58,6 +58,20 @@ export function getItemData(snapshot) {
 		 */
 		data.id = docRef.id;
 
+		let isDefaultChecked;
+
+		if (!data.dateLastPurchased) {
+			isDefaultChecked = false;
+		} else {
+			const dayInMilliseconds = 24 * 60 * 60 * 1000;
+			const date = data.dateLastPurchased.toDate();
+			const currentDate = new Date();
+			const timeElapsed = currentDate - date;
+			isDefaultChecked = timeElapsed < dayInMilliseconds;
+		}
+
+		data.isDefaultChecked = isDefaultChecked;
+
 		return data;
 	});
 }

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -4,6 +4,8 @@ import {
 	onSnapshot,
 	getDocs,
 	getDoc,
+	updateDoc,
+	doc,
 } from 'firebase/firestore';
 import { db } from './config';
 import { getFutureDate } from '../utils';
@@ -81,22 +83,11 @@ export async function addItem(listId, { itemName, daysUntilNextPurchase }) {
 }
 
 export async function updateItem(listId, listItemId) {
-	//FIRESTORE SAMPLE
+	const listItemRef = doc(db, listId, listItemId);
 
-	const listItemRef = collection(db, listId, listItemId);
-	const listItemSnapShot = await getDoc(listItemRef);
-	const result = await listItemSnapShot.update({
+	await updateDoc(listItemRef, {
 		dateLastPurchased: new Date(),
 	});
-
-	// db.collection(listId).doc(listItemId);
-	// const res = await listItemRef.update({dateLastPurchased: new Date()});
-
-	/**
-	 * TODO: Fill this out so that it uses the correct Firestore function
-	 * to update an existing item. You'll need to figure out what arguments
-	 * this function must accept!
-	 */
 }
 
 export async function deleteItem() {

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -2,7 +2,7 @@ import './ListItem.css';
 
 export function ListItem({
 	name,
-	dateLastPurchased,
+	isDefaultChecked,
 	itemId,
 	setIsChecked,
 	setCheckedItemId,
@@ -10,17 +10,6 @@ export function ListItem({
 	function clickHandler(event, itemId) {
 		setIsChecked(event.target.checked);
 		setCheckedItemId(itemId);
-	}
-
-	function checkDefault() {
-		if (!dateLastPurchased) return false;
-		const dayInMilliseconds = 24 * 60 * 60 * 1000;
-		const date = dateLastPurchased.toDate();
-		const currentDate = new Date();
-		const timeElapsed = currentDate - date;
-
-		if (timeElapsed > dayInMilliseconds) return false;
-		else return true;
 	}
 
 	return (
@@ -31,7 +20,7 @@ export function ListItem({
 				onClick={(event) => {
 					clickHandler(event, itemId);
 				}}
-				defaultChecked={checkDefault()}
+				defaultChecked={isDefaultChecked}
 			/>
 			<label htmlFor={itemId}>{name}</label>
 		</li>

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,5 +1,10 @@
 import './ListItem.css';
 
-export function ListItem({ name }) {
-	return <li className="ListItem">{name}</li>;
+export function ListItem({ name, itemId }) {
+	return (
+		<li className="ListItem">
+			<input type="checkbox" id={itemId} />
+			<label htmlFor={itemId}>{name}</label>
+		</li>
+	);
 }

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,14 +1,17 @@
 import './ListItem.css';
 
-// Passing to each list item the setter function "setCheckedItem"
+export function ListItem({ name, itemId, setIsChecked, setCheckedItemId }) {
+	function clickHandler(event, itemId) {
+		setIsChecked(event.target.checked);
+		setCheckedItemId(itemId);
+	}
 
-export function ListItem({ name, itemId, setCheckedItemId }) {
 	return (
 		<li className="ListItem">
 			<input
 				type="checkbox"
 				id={itemId}
-				onChange={() => setCheckedItemId(itemId)}
+				onClick={(event) => clickHandler(event, itemId)}
 			/>
 			<label htmlFor={itemId}>{name}</label>
 		</li>

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,9 +1,15 @@
 import './ListItem.css';
 
-export function ListItem({ name, itemId }) {
+// Passing to each list item the setter function "setCheckedItem"
+
+export function ListItem({ name, itemId, setCheckedItemId }) {
 	return (
 		<li className="ListItem">
-			<input type="checkbox" id={itemId} />
+			<input
+				type="checkbox"
+				id={itemId}
+				onChange={() => setCheckedItemId(itemId)}
+			/>
 			<label htmlFor={itemId}>{name}</label>
 		</li>
 	);

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,9 +1,26 @@
 import './ListItem.css';
 
-export function ListItem({ name, itemId, setIsChecked, setCheckedItemId }) {
+export function ListItem({
+	name,
+	dateLastPurchased,
+	itemId,
+	setIsChecked,
+	setCheckedItemId,
+}) {
 	function clickHandler(event, itemId) {
 		setIsChecked(event.target.checked);
 		setCheckedItemId(itemId);
+	}
+
+	function checkDefault() {
+		if (!dateLastPurchased) return false;
+		const dayInMilliseconds = 24 * 60 * 60 * 1000;
+		const date = dateLastPurchased.toDate();
+		const currentDate = new Date();
+		const timeElapsed = currentDate - date;
+
+		if (timeElapsed > dayInMilliseconds) return false;
+		else return true;
 	}
 
 	return (
@@ -11,7 +28,10 @@ export function ListItem({ name, itemId, setIsChecked, setCheckedItemId }) {
 			<input
 				type="checkbox"
 				id={itemId}
-				onClick={(event) => clickHandler(event, itemId)}
+				onClick={(event) => {
+					clickHandler(event, itemId);
+				}}
+				defaultChecked={checkDefault()}
 			/>
 			<label htmlFor={itemId}>{name}</label>
 		</li>

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -1,4 +1,5 @@
-const ONE_DAY_IN_MILLISECONDS = 86400000;
+export const ONE_DAY_IN_MILLISECONDS = 86400000;
+export const CURRENT_DATE = new Date();
 
 /**
  * Get a new JavaScript Date that is `offset` days in the future.

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -7,6 +7,8 @@ export function List({ data, listToken }) {
 	const [checkedItemId, setCheckedItemId] = useState('');
 	const [isChecked, setIsChecked] = useState(false);
 
+	/*TO DO: Implement guard against user's accidental click. Currently the updated fields (dateLastPurchased and totalPurchases) in Firestore 
+	persist when user unchecks item.*/
 	useEffect(() => {
 		if (isChecked) {
 			updateItem(listToken, checkedItemId);

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -15,7 +15,7 @@ export function List({ data }) {
 	});
 
 	const renderedList = filteredList.map((item) => (
-		<ListItem name={item.name} key={item.id} />
+		<ListItem name={item.name} key={item.id} itemId={item.id} />
 	));
 
 	const clearSearchField = (e) => {

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -1,8 +1,14 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { ListItem } from '../components';
+import { updateItem } from '../api/firebase.js';
 
-export function List({ data }) {
+export function List({ data, listToken }) {
 	const [searchTerm, setSearchTerm] = useState('');
+	const [checkedItemId, setCheckedItemId] = useState('');
+
+	useEffect(() => {
+		updateItem(listToken, checkedItemId);
+	}, [checkedItemId]);
 
 	/* TO DO: Make separate resuable input component with a filter feature*/
 
@@ -15,7 +21,12 @@ export function List({ data }) {
 	});
 
 	const renderedList = filteredList.map((item) => (
-		<ListItem name={item.name} key={item.id} itemId={item.id} />
+		<ListItem
+			name={item.name}
+			key={item.id}
+			itemId={item.id}
+			setCheckedItemId={setCheckedItemId}
+		/>
 	));
 
 	const clearSearchField = (e) => {

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -5,12 +5,13 @@ import { updateItem } from '../api/firebase.js';
 export function List({ data, listToken }) {
 	const [searchTerm, setSearchTerm] = useState('');
 	const [checkedItemId, setCheckedItemId] = useState('');
+	const [isChecked, setIsChecked] = useState(false);
 
 	useEffect(() => {
-		updateItem(listToken, checkedItemId);
-	}, [listToken, checkedItemId]);
-
-	/* TO DO: Make separate resuable input component with a filter feature*/
+		if (isChecked) {
+			updateItem(listToken, checkedItemId);
+		}
+	}, [isChecked, listToken, checkedItemId]);
 
 	const filteredList = data.filter((item) => {
 		if (searchTerm === '') {
@@ -26,6 +27,7 @@ export function List({ data, listToken }) {
 			key={item.id}
 			itemId={item.id}
 			setCheckedItemId={setCheckedItemId}
+			setIsChecked={setIsChecked}
 		/>
 	));
 

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -24,6 +24,7 @@ export function List({ data, listToken }) {
 	const renderedList = filteredList.map((item) => (
 		<ListItem
 			name={item.name}
+			dateLastPurchased={item.dateLastPurchased}
 			key={item.id}
 			itemId={item.id}
 			setCheckedItemId={setCheckedItemId}

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -8,7 +8,7 @@ export function List({ data, listToken }) {
 
 	useEffect(() => {
 		updateItem(listToken, checkedItemId);
-	}, [checkedItemId]);
+	}, [listToken, checkedItemId]);
 
 	/* TO DO: Make separate resuable input component with a filter feature*/
 

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -24,7 +24,7 @@ export function List({ data, listToken }) {
 	const renderedList = filteredList.map((item) => (
 		<ListItem
 			name={item.name}
-			dateLastPurchased={item.dateLastPurchased}
+			isDefaultChecked={item.isDefaultChecked}
 			key={item.id}
 			itemId={item.id}
 			setCheckedItemId={setCheckedItemId}


### PR DESCRIPTION


## Description

<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? Reminder: This will be a publicly facing representation of your work (READ: help you land that sweet dev gig). -->

Before this PR, users were presented with a static view of their grocery list. This PR adds functionality to the application that allows users to interact with their list so that they can keep track of the things they need to buy, and do not need to buy, at any given point in time. This was accomplished by enhancing the user's list view page with a user interface consisting of checkboxes alongside each item on their list that they can checkoff after purchasing. The item remains marked for a 24 hour window after the purchase. And after 24 hours, the application programmatically unchecks the item so that it is available for when the user needs to purchase it again.



## Related Issue

<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->

Closes #8. 

## Acceptance Criteria

<!-- Include AC from the Github issue -->

- [x] The `ListItem` component renders a checkbox with a semantic `<label>`.
- [x] Checking off the item in the UI also updates the `dateLastPurchased` and `totalPurchases` properties on the corresponding Firestore document
- [x] The item is shown as checked for 24 hours after the purchase is made (i.e. we assume the user does not need to buy the item again for at least 1 day). After 24 hours, the item unchecks itself so the user can buy it again.
- [x] The `updateItem` function in `firebase.js` has been filled out, and sends updates to the firestore database when an item is checked or un-checked


## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before
On the `List` view, there are no checkboxes next to the list items. Looking up `State` in the browser dev tools shows `lastDatePurchased` as `null` and `totalPurchases` as `0`. This can also be seen from the Firestore database console (see QA steps below.) 
![Capture](https://user-images.githubusercontent.com/63743078/234950974-60d5128b-1756-4243-bce7-07bfa2b8d489.PNG)

<!-- If UI feature, take provide screenshots -->

### After
Each item now has a checkbox. Checking the box updates the `dateLastPurchased` to the current date and increases `totalPurchases` by 1 in the Firestore database. The checkmark automatically unchecks after 24 hours, as demonstrated by rolling back `dateLastPurchased` manually in Firestore.

[screen-capture (1).webm](https://user-images.githubusercontent.com/63743078/234954221-dbc5ec02-94d5-4a27-b8d5-96cb6122d290.webm)

<!-- If UI feature, take provide screenshots -->

## Testing Steps / QA Criteria
**To Check that the dateLastPurchased and totalPurchases have been updated:** 
- Click on the Preview Link in this Pull Request
- Go through the steps of creating a new list token from `Home` or type in the token for an exisiting list. 
- If creating a new list, go through the steps of adding items to your list from the the `Add Item` view.
- Find your token name under `Application` in your browser dev tools.
- Navigate to the Firestore database console and look up your list by token name under the first column, and click on the first item in the second column: https://console.firebase.google.com/u/0/project/tcl-57-smart-shopping-list/firestore/data/
- The `dateLastPurchased` attribute for that item should say `null` and the totalPurchases should be set to `0`.
- Navigate back to your list from `List` view on the Smart Shopping List app.
- Check the corresponding item you want purchased.
- Navigate back to Firebase console. `dateLastPurchased` and `totalPurchases` should update to today's date and `1`.


**To Check for the 24-hour automatic uncheck functionality:** 
- Navigate back to app and refresh page. Checkmark next to item should remain.
- From the Firebase console, manually roll back the `dateLastPurchased` on your item by 1 day. 
- Navigate back to your `List` in the app. 
- Refresh the browser, and the item should now be automatically unchecked.

