### PR TITLE
Empty Submission or Duplicate Item Alerts

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -76,7 +76,10 @@ export function App() {
 							)
 						}
 					/>
-					<Route path="/add-item" element={<AddItem listToken={listToken} />} />
+					<Route
+						path="/add-item"
+						element={<AddItem data={data} listToken={listToken} />}
+					/>
 				</Route>
 			</Routes>
 		</Router>

--- a/src/views/AddItem.jsx
+++ b/src/views/AddItem.jsx
@@ -10,15 +10,21 @@ export function AddItem({ listToken, data }) {
 	const handleSubmit = async (e) => {
 		e.preventDefault();
 		const normalizedItemName = itemName.replace(/[\s\W]|_+/g, '').toLowerCase();
+
+		if (normalizedItemName === '') {
+			setUserAlertMessage('Please enter an item name.');
+			return;
+		}
+
 		for (const item of data) {
 			const existingItem = item.name;
 			const updatedExistingItem = existingItem
 				.replace(/[\s\W]|_+/g, '')
 				.toLowerCase();
-			if (normalizedItemName === '') {
-				setUserAlertMessage('Please enter an item name.');
-				return;
-			}
+			// if (normalizedItemName === '') {
+			// 	setUserAlertMessage('Please enter an item name.');
+			// 	return;
+			// }
 			if (normalizedItemName === updatedExistingItem) {
 				setUserAlertMessage(
 					`The item '${existingItem}' is already on your list.`,

--- a/src/views/AddItem.jsx
+++ b/src/views/AddItem.jsx
@@ -21,10 +21,7 @@ export function AddItem({ listToken, data }) {
 			const updatedExistingItem = existingItem
 				.replace(/[\s\W]|_+/g, '')
 				.toLowerCase();
-			// if (normalizedItemName === '') {
-			// 	setUserAlertMessage('Please enter an item name.');
-			// 	return;
-			// }
+
 			if (normalizedItemName === updatedExistingItem) {
 				setUserAlertMessage(
 					`The item '${existingItem}' is already on your list.`,

--- a/src/views/AddItem.jsx
+++ b/src/views/AddItem.jsx
@@ -26,6 +26,9 @@ export function AddItem({ listToken }) {
 		//		if (updatedItem === existingItem) {
 		// 			alert user;
 		// 			return;}
+		let updatedUserInput = itemName.replace(/\s/g, '').toLowerCase();
+		let noPunctuationUserInput = updatedUserInput.replace(/[^\w\s]|_/g, '');
+		console.log(noPunctuationUserInput);
 		// 		else
 		try {
 			await addItem(listToken, {

--- a/src/views/AddItem.jsx
+++ b/src/views/AddItem.jsx
@@ -6,10 +6,13 @@ export function AddItem({ listToken, data }) {
 	const [daysUntilNextPurchase, setDaysUntilNextPurchase] = useState(7);
 	const [error, setError] = useState(false);
 	const [userAlertMessage, setUserAlertMessage] = useState('');
+	const normalizedItemNameRegex = /[\s\W]|_+/g;
 
 	const handleSubmit = async (e) => {
 		e.preventDefault();
-		const normalizedItemName = itemName.replace(/[\s\W]|_+/g, '').toLowerCase();
+		const normalizedItemName = itemName
+			.replace(normalizedItemNameRegex, '')
+			.toLowerCase();
 
 		if (normalizedItemName === '') {
 			setUserAlertMessage('Please enter an item name.');
@@ -19,7 +22,7 @@ export function AddItem({ listToken, data }) {
 		for (const item of data) {
 			const existingItem = item.name;
 			const updatedExistingItem = existingItem
-				.replace(/[\s\W]|_+/g, '')
+				.replace(normalizedItemNameRegex, '')
 				.toLowerCase();
 
 			if (normalizedItemName === updatedExistingItem) {

--- a/src/views/AddItem.jsx
+++ b/src/views/AddItem.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { addItem } from '../api/firebase.js';
 
-export function AddItem({ listToken }) {
+export function AddItem({ listToken, data }) {
 	const [itemName, setItemName] = useState('');
 	const [daysUntilNextPurchase, setDaysUntilNextPurchase] = useState(7);
 	const [itemAdded, setItemAdded] = useState(false);
@@ -15,6 +15,7 @@ export function AddItem({ listToken }) {
 		// 		if (user item name input === '') {
 		// 			alert user;
 		// 			return;}
+
 		if (itemName === '') {
 			window.alert('Please enter an item name');
 			return;
@@ -33,7 +34,8 @@ export function AddItem({ listToken }) {
 		// 			return;}
 		let updatedUserInput = itemName.replace(/\s/g, '').toLowerCase();
 		let noPunctuationUserInput = updatedUserInput.replace(/[^\w\s]|_/g, '');
-		console.log(noPunctuationUserInput);
+		//console.log(noPunctuationUserInput);
+		//FILTER THROUGH THE DATA ARRAY AND MAKE EACH ITEM LOWERCASE WITHOUT SPACES AND PUNCTUATION. SAVE TO A NEW VARIABLE.
 		// 		else
 		try {
 			await addItem(listToken, {

--- a/src/views/AddItem.jsx
+++ b/src/views/AddItem.jsx
@@ -16,10 +16,10 @@ export function AddItem({ listToken, data }) {
 		// 			alert user;
 		// 			return;}
 
-		if (itemName === '') {
-			window.alert('Please enter an item name');
-			return;
-		}
+		// if (itemName === '') {
+		// 	window.alert('Please enter an item name');
+		// 	return;
+		// }
 
 		// 2. If user's item name input is identical to an existing item, alert user and don't save input to database.
 		//		if (user item name input === existing item) {
@@ -32,18 +32,24 @@ export function AddItem({ listToken, data }) {
 		//		if (updatedItem === existingItem) {
 		// 			alert user;
 		// 			return;}
-		let updatedUserInput = itemName.replace(/\s/g, '').toLowerCase();
-		let noPunctuationUserInput = updatedUserInput.replace(/[^\w\s]|_/g, '');
+		const normalizedItemName = itemName.replace(/[\s\W]|_+/g, '').toLowerCase();
+		// let updatedUserInput = itemName.replace(/\s/g, '').toLowerCase();
+		// let noPunctuationUserInput = updatedUserInput.replace(/[^\w\s]|_/g, '');
 		//console.log(noPunctuationUserInput);
 		//FILTER THROUGH THE DATA ARRAY AND MAKE EACH ITEM LOWERCASE WITHOUT SPACES AND PUNCTUATION. SAVE TO A NEW VARIABLE.
-
 		for (const item of data) {
 			const existingItem = item.name;
-			const updateExistingItem = existingItem
-				.replace(/[^\w\s]|_/g, '')
-				.replace(/\s/g, '')
+			const updatedExistingItem = existingItem
+				.replace(/[\s\W]|_+/g, '')
+				// .replace(/[^\w\s]|_/g, '')
+				// .replace(/\s/g, '')
 				.toLowerCase();
-			if (noPunctuationUserInput === updateExistingItem) {
+			// if (noPunctuationUserInput === updateExistingItem) {
+			if (normalizedItemName === '') {
+				window.alert('Please enter an item name');
+				return;
+			}
+			if (normalizedItemName === updatedExistingItem) {
 				window.alert(`${existingItem} is already on your list.`);
 				return;
 			}

--- a/src/views/AddItem.jsx
+++ b/src/views/AddItem.jsx
@@ -37,7 +37,9 @@ export function AddItem({ listToken, data }) {
 				return;
 			}
 			if (normalizedItemName === updatedExistingItem) {
-				setUserAlertMessage(`${existingItem} is already on your list.`);
+				setUserAlertMessage(
+					`The item '${existingItem}' is already on your list.`,
+				);
 				return;
 			}
 		}

--- a/src/views/AddItem.jsx
+++ b/src/views/AddItem.jsx
@@ -7,7 +7,6 @@ export function AddItem({ listToken, data }) {
 	const [itemAdded, setItemAdded] = useState(false);
 	const [error, setError] = useState(false);
 
-	// TODO: dynamically pass in the list token so item is added to correct list
 	const handleSubmit = async (e) => {
 		e.preventDefault();
 		// Pseudocode:
@@ -15,12 +14,6 @@ export function AddItem({ listToken, data }) {
 		// 		if (user item name input === '') {
 		// 			alert user;
 		// 			return;}
-
-		// if (itemName === '') {
-		// 	window.alert('Please enter an item name');
-		// 	return;
-		// }
-
 		// 2. If user's item name input is identical to an existing item, alert user and don't save input to database.
 		//		if (user item name input === existing item) {
 		//			alert user;
@@ -28,23 +21,17 @@ export function AddItem({ listToken, data }) {
 		// 3. If user's item name input has unconventional title case or spacing but still matches an existing item, alert user OR user confirms and don't save input to datebase.
 		//		const updatedItem = user item input, converted to lower case and spaces removed
 		// 		(ex: "App les" becomes "apples", "root beer" becomes "rootbeer")
+		const normalizedItemName = itemName.replace(/[\s\W]|_+/g, '').toLowerCase();
 		//		const existingItem = existing item, converted to lower case and spaces removed
 		//		if (updatedItem === existingItem) {
 		// 			alert user;
 		// 			return;}
-		const normalizedItemName = itemName.replace(/[\s\W]|_+/g, '').toLowerCase();
-		// let updatedUserInput = itemName.replace(/\s/g, '').toLowerCase();
-		// let noPunctuationUserInput = updatedUserInput.replace(/[^\w\s]|_/g, '');
-		//console.log(noPunctuationUserInput);
 		//FILTER THROUGH THE DATA ARRAY AND MAKE EACH ITEM LOWERCASE WITHOUT SPACES AND PUNCTUATION. SAVE TO A NEW VARIABLE.
 		for (const item of data) {
 			const existingItem = item.name;
 			const updatedExistingItem = existingItem
 				.replace(/[\s\W]|_+/g, '')
-				// .replace(/[^\w\s]|_/g, '')
-				// .replace(/\s/g, '')
 				.toLowerCase();
-			// if (noPunctuationUserInput === updateExistingItem) {
 			if (normalizedItemName === '') {
 				window.alert('Please enter an item name');
 				return;
@@ -54,7 +41,6 @@ export function AddItem({ listToken, data }) {
 				return;
 			}
 		}
-
 		// 		else
 		try {
 			await addItem(listToken, {

--- a/src/views/AddItem.jsx
+++ b/src/views/AddItem.jsx
@@ -36,6 +36,19 @@ export function AddItem({ listToken, data }) {
 		let noPunctuationUserInput = updatedUserInput.replace(/[^\w\s]|_/g, '');
 		//console.log(noPunctuationUserInput);
 		//FILTER THROUGH THE DATA ARRAY AND MAKE EACH ITEM LOWERCASE WITHOUT SPACES AND PUNCTUATION. SAVE TO A NEW VARIABLE.
+
+		for (const item of data) {
+			const existingItem = item.name;
+			const updateExistingItem = existingItem
+				.replace(/[^\w\s]|_/g, '')
+				.replace(/\s/g, '')
+				.toLowerCase();
+			if (noPunctuationUserInput === updateExistingItem) {
+				window.alert(`${existingItem} is already on your list.`);
+				return;
+			}
+		}
+
 		// 		else
 		try {
 			await addItem(listToken, {

--- a/src/views/AddItem.jsx
+++ b/src/views/AddItem.jsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { addItem } from '../api/firebase.js';
-import { userEvent } from '@testing-library/user-event/dist/types/setup/index.js';
 
 export function AddItem({ listToken }) {
 	const [itemName, setItemName] = useState('');

--- a/src/views/AddItem.jsx
+++ b/src/views/AddItem.jsx
@@ -6,13 +6,13 @@ export function AddItem({ listToken, data }) {
 	const [daysUntilNextPurchase, setDaysUntilNextPurchase] = useState(7);
 	const [error, setError] = useState(false);
 	const [userAlertMessage, setUserAlertMessage] = useState('');
-	const normalizedItemNameRegex = /[\s\W]|_+/g;
+	const normalizedItemNameRegex = /[\s\W]|_+|s$/g; //Targets all spaces, non-letter characters, and 's' character at the end of the string
 
 	const handleSubmit = async (e) => {
 		e.preventDefault();
 		const normalizedItemName = itemName
-			.replace(normalizedItemNameRegex, '')
-			.toLowerCase();
+			.toLowerCase()
+			.replace(normalizedItemNameRegex, '');
 
 		if (normalizedItemName === '') {
 			setUserAlertMessage('Please enter an item name.');
@@ -22,8 +22,8 @@ export function AddItem({ listToken, data }) {
 		for (const item of data) {
 			const existingItem = item.name;
 			const updatedExistingItem = existingItem
-				.replace(normalizedItemNameRegex, '')
-				.toLowerCase();
+				.toLowerCase()
+				.replace(normalizedItemNameRegex, '');
 
 			if (normalizedItemName === updatedExistingItem) {
 				setUserAlertMessage(

--- a/src/views/AddItem.jsx
+++ b/src/views/AddItem.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { addItem } from '../api/firebase.js';
+import { userEvent } from '@testing-library/user-event/dist/types/setup/index.js';
 
 export function AddItem({ listToken }) {
 	const [itemName, setItemName] = useState('');
@@ -10,6 +11,23 @@ export function AddItem({ listToken }) {
 	// TODO: dynamically pass in the list token so item is added to correct list
 	const handleSubmit = async (e) => {
 		e.preventDefault();
+		// Pseudocode:
+		// 1. If user's item name input is empty, alert user and don't save input to database.
+		// 		if (user item name input === '') {
+		// 			alert user;
+		// 			return;}
+		// 2. If user's item name input is identical to an existing item, alert user and don't save input to database.
+		//		if (user item name input === existing item) {
+		//			alert user;
+		// 			return;}
+		// 3. If user's item name input has unconventional title case or spacing but still matches an existing item, alert user OR user confirms and don't save input to datebase.
+		//		const updatedItem = user item input, converted to lower case and spaces removed
+		// 		(ex: "App les" becomes "apples", "root beer" becomes "rootbeer")
+		//		const existingItem = existing item, converted to lower case and spaces removed
+		//		if (updatedItem === existingItem) {
+		// 			alert user;
+		// 			return;}
+		// 		else
 		try {
 			await addItem(listToken, {
 				itemName,

--- a/src/views/AddItem.jsx
+++ b/src/views/AddItem.jsx
@@ -15,6 +15,11 @@ export function AddItem({ listToken }) {
 		// 		if (user item name input === '') {
 		// 			alert user;
 		// 			return;}
+		if (itemName === '') {
+			window.alert('Please enter an item name');
+			return;
+		}
+
 		// 2. If user's item name input is identical to an existing item, alert user and don't save input to database.
 		//		if (user item name input === existing item) {
 		//			alert user;

--- a/src/views/AddItem.jsx
+++ b/src/views/AddItem.jsx
@@ -9,24 +9,7 @@ export function AddItem({ listToken, data }) {
 
 	const handleSubmit = async (e) => {
 		e.preventDefault();
-		// Pseudocode:
-		// 1. If user's item name input is empty, alert user and don't save input to database.
-		// 		if (user item name input === '') {
-		// 			alert user;
-		// 			return;}
-		// 2. If user's item name input is identical to an existing item, alert user and don't save input to database.
-		//		if (user item name input === existing item) {
-		//			alert user;
-		// 			return;}
-		// 3. If user's item name input has unconventional title case or spacing but still matches an existing item, alert user OR user confirms and don't save input to datebase.
-		//		const updatedItem = user item input, converted to lower case and spaces removed
-		// 		(ex: "App les" becomes "apples", "root beer" becomes "rootbeer")
 		const normalizedItemName = itemName.replace(/[\s\W]|_+/g, '').toLowerCase();
-		//		const existingItem = existing item, converted to lower case and spaces removed
-		//		if (updatedItem === existingItem) {
-		// 			alert user;
-		// 			return;}
-		//FILTER THROUGH THE DATA ARRAY AND MAKE EACH ITEM LOWERCASE WITHOUT SPACES AND PUNCTUATION. SAVE TO A NEW VARIABLE.
 		for (const item of data) {
 			const existingItem = item.name;
 			const updatedExistingItem = existingItem
@@ -43,7 +26,6 @@ export function AddItem({ listToken, data }) {
 				return;
 			}
 		}
-		// 		else
 		try {
 			await addItem(listToken, {
 				itemName,

--- a/src/views/AddItem.jsx
+++ b/src/views/AddItem.jsx
@@ -4,8 +4,8 @@ import { addItem } from '../api/firebase.js';
 export function AddItem({ listToken, data }) {
 	const [itemName, setItemName] = useState('');
 	const [daysUntilNextPurchase, setDaysUntilNextPurchase] = useState(7);
-	const [itemAdded, setItemAdded] = useState(false);
 	const [error, setError] = useState(false);
+	const [userAlertMessage, setUserAlertMessage] = useState('');
 
 	const handleSubmit = async (e) => {
 		e.preventDefault();
@@ -33,11 +33,11 @@ export function AddItem({ listToken, data }) {
 				.replace(/[\s\W]|_+/g, '')
 				.toLowerCase();
 			if (normalizedItemName === '') {
-				window.alert('Please enter an item name');
+				setUserAlertMessage('Please enter an item name.');
 				return;
 			}
 			if (normalizedItemName === updatedExistingItem) {
-				window.alert(`${existingItem} is already on your list.`);
+				setUserAlertMessage(`${existingItem} is already on your list.`);
 				return;
 			}
 		}
@@ -47,11 +47,11 @@ export function AddItem({ listToken, data }) {
 				itemName,
 				daysUntilNextPurchase,
 			});
-			setItemAdded(true);
+			setUserAlertMessage(`${itemName} has been added to your list.`);
 			setError(false);
 		} catch (e) {
 			setError(true);
-			setItemAdded(false);
+			setUserAlertMessage('');
 		}
 	};
 	// TODO: implement clear input after user adds item to list
@@ -93,8 +93,7 @@ export function AddItem({ listToken, data }) {
 				<input type="submit" value="Add item" />
 			</form>
 			{/* TODO: we could change item added message to a toast message, alert, timeout or use third-party library for this message. */}
-			{itemAdded && <p>Your item has been added.</p>}
-			{error && <p>Oh no, something went wrong.</p>}
+			{error ? <p>Oh no, something went wrong.</p> : <p>{userAlertMessage}</p>}
 		</>
 	);
 }


### PR DESCRIPTION


## Description
This pull request sets up a series of alerts in the `Add Item` view based on user input. It guards against the user attempts to add empty strings or duplicate items onto their list. The input defense takes into account unconventional spellings, capitalization, and punctuation when recognizing duplicate items. We accomplished this by using regular expressions to normalize the existing list item strings and the input strings before comparing them. The user will be alerted if 1) No item was entered or only empty spaces or non-letter characters were entered into the input field, and if 2) There is already an item on the list that is identical or recognizably the same as the user input once it is stripped of caps, punctuation, and spaces (e.g., "root beer" compared to "Rootbeer").  


<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? Reminder: This will be a publicly facing representation of your work (READ: help you land that sweet dev gig). -->

## Related Issue
Closes #9 

<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->

## Acceptance Criteria

- [x] Show an error message if the user tries to submit an empty item
- [x] Show an error message if the user tries to submit a new item that is identical to an existing name. For instance, if the list contains apples and the user adds apples.
- [x] Show an error message if the user tries to submit a new item that matches an existing name with punctuation and casing normalized. For instance, if the list contains apples and the user adds aPples or apples, or a pples.
- [x] The user’s original input is saved in the database

<!-- Include AC from the Github issue -->

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before
This before video shows that the user is able to add an empty item to their list, or add the same item twice.

https://user-images.githubusercontent.com/84364905/236110996-f4018437-b7e0-4e09-97a7-e740b09efb32.mov



### After
In this after video, when the user tries to enter an empty item or an item containing only spaces or non-letter characters, they get a message stating "Please enter an item name." If the user tries to add an item that already exists on their list (regardless of case, punctuation or extra whitespace), they get a message that says "The item _'your item name input'_ is already on your list. Lastly, the Firestore database shows that the item was saved exactly as the user input it (not normalized).

https://user-images.githubusercontent.com/84364905/236112094-06724402-660d-461d-83e1-4e7e706bac7c.mov

## Testing Steps / QA Criteria

- Visit the preview URL for this PR: https://tcl-57-smart-shopping-list--pr27-ap-es-empty-or-dupli-2avec41j.web.app/
- Create a new list or enter token to view existing list
- Navigate to the `Add Item` page
- Without entering anything in the item input, click the form "Submit" button. The message "Please enter an item name." should appear below the form.
     - Typing any number of spaces, without any letters, in the item name input and submitting the form should return the same message.
- Submit a new item and then try to submit that same item again. The message "The item '<_your item name input_>' is already on your list." should appear. Check the `List` page to confirm that the item only appears once.
     - This message should appear regardless of any change in case, spacing or inclusion of non-letter characters. For example: if `carrots` is already on your list, submitting `&CarR ot s!` will still return this same message.
- Visit the Firestore database to confirm that your items were saved exactly as you input them.
