### PR TITLE
Feature: import Material UI component library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,9 @@
 		"": {
 			"name": "smart-shopping-list-next",
 			"dependencies": {
+				"@emotion/react": "^11.11.0",
+				"@emotion/styled": "^11.11.0",
+				"@mui/material": "^5.13.1",
 				"@the-collab-lab/shopping-list-utils": "^2.0.0",
 				"firebase": "^9.17.2",
 				"react": "^18.2.0",
@@ -60,7 +63,6 @@
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
 			"integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
-			"dev": true,
 			"dependencies": {
 				"@babel/highlight": "^7.18.6"
 			},
@@ -324,7 +326,6 @@
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
 			"integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
-			"dev": true,
 			"dependencies": {
 				"@babel/types": "^7.18.6"
 			},
@@ -447,7 +448,6 @@
 			"version": "7.19.4",
 			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
 			"integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==",
-			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -456,7 +456,6 @@
 			"version": "7.19.1",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
 			"integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
-			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -503,7 +502,6 @@
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
 			"integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
-			"dev": true,
 			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.18.6",
 				"chalk": "^2.0.0",
@@ -517,7 +515,6 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
 			"dependencies": {
 				"color-convert": "^1.9.0"
 			},
@@ -529,7 +526,6 @@
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
 			"dependencies": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -543,7 +539,6 @@
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
 			"dependencies": {
 				"color-name": "1.1.3"
 			}
@@ -551,14 +546,12 @@
 		"node_modules/@babel/highlight/node_modules/color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-			"dev": true
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
 		},
 		"node_modules/@babel/highlight/node_modules/escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.8.0"
 			}
@@ -567,7 +560,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -576,7 +568,6 @@
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dev": true,
 			"dependencies": {
 				"has-flag": "^3.0.0"
 			},
@@ -1956,7 +1947,6 @@
 			"version": "7.21.0",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
 			"integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
-			"dev": true,
 			"dependencies": {
 				"regenerator-runtime": "^0.13.11"
 			},
@@ -2003,7 +1993,6 @@
 			"version": "7.21.3",
 			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.3.tgz",
 			"integrity": "sha512-sBGdETxC+/M4o/zKC0sl6sjWv62WFR/uzxrJ6uYyMLZOUlPnwzw0tKgVHOXxaAd5l2g8pEDM5RZ495GPQI77kg==",
-			"dev": true,
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.19.4",
 				"@babel/helper-validator-identifier": "^7.19.1",
@@ -2012,6 +2001,147 @@
 			"engines": {
 				"node": ">=6.9.0"
 			}
+		},
+		"node_modules/@emotion/babel-plugin": {
+			"version": "11.11.0",
+			"resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz",
+			"integrity": "sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==",
+			"dependencies": {
+				"@babel/helper-module-imports": "^7.16.7",
+				"@babel/runtime": "^7.18.3",
+				"@emotion/hash": "^0.9.1",
+				"@emotion/memoize": "^0.8.1",
+				"@emotion/serialize": "^1.1.2",
+				"babel-plugin-macros": "^3.1.0",
+				"convert-source-map": "^1.5.0",
+				"escape-string-regexp": "^4.0.0",
+				"find-root": "^1.1.0",
+				"source-map": "^0.5.7",
+				"stylis": "4.2.0"
+			}
+		},
+		"node_modules/@emotion/babel-plugin/node_modules/source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@emotion/cache": {
+			"version": "11.11.0",
+			"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.11.0.tgz",
+			"integrity": "sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==",
+			"dependencies": {
+				"@emotion/memoize": "^0.8.1",
+				"@emotion/sheet": "^1.2.2",
+				"@emotion/utils": "^1.2.1",
+				"@emotion/weak-memoize": "^0.3.1",
+				"stylis": "4.2.0"
+			}
+		},
+		"node_modules/@emotion/hash": {
+			"version": "0.9.1",
+			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
+			"integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
+		},
+		"node_modules/@emotion/is-prop-valid": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
+			"integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
+			"dependencies": {
+				"@emotion/memoize": "^0.8.1"
+			}
+		},
+		"node_modules/@emotion/memoize": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+			"integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
+		},
+		"node_modules/@emotion/react": {
+			"version": "11.11.0",
+			"resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.0.tgz",
+			"integrity": "sha512-ZSK3ZJsNkwfjT3JpDAWJZlrGD81Z3ytNDsxw1LKq1o+xkmO5pnWfr6gmCC8gHEFf3nSSX/09YrG67jybNPxSUw==",
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"@emotion/babel-plugin": "^11.11.0",
+				"@emotion/cache": "^11.11.0",
+				"@emotion/serialize": "^1.1.2",
+				"@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
+				"@emotion/utils": "^1.2.1",
+				"@emotion/weak-memoize": "^0.3.1",
+				"hoist-non-react-statics": "^3.3.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@emotion/serialize": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.2.tgz",
+			"integrity": "sha512-zR6a/fkFP4EAcCMQtLOhIgpprZOwNmCldtpaISpvz348+DP4Mz8ZoKaGGCQpbzepNIUWbq4w6hNZkwDyKoS+HA==",
+			"dependencies": {
+				"@emotion/hash": "^0.9.1",
+				"@emotion/memoize": "^0.8.1",
+				"@emotion/unitless": "^0.8.1",
+				"@emotion/utils": "^1.2.1",
+				"csstype": "^3.0.2"
+			}
+		},
+		"node_modules/@emotion/sheet": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.2.tgz",
+			"integrity": "sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA=="
+		},
+		"node_modules/@emotion/styled": {
+			"version": "11.11.0",
+			"resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.11.0.tgz",
+			"integrity": "sha512-hM5Nnvu9P3midq5aaXj4I+lnSfNi7Pmd4EWk1fOZ3pxookaQTNew6bp4JaCBYM4HVFZF9g7UjJmsUmC2JlxOng==",
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"@emotion/babel-plugin": "^11.11.0",
+				"@emotion/is-prop-valid": "^1.2.1",
+				"@emotion/serialize": "^1.1.2",
+				"@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
+				"@emotion/utils": "^1.2.1"
+			},
+			"peerDependencies": {
+				"@emotion/react": "^11.0.0-rc.0",
+				"react": ">=16.8.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@emotion/unitless": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
+			"integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
+		},
+		"node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz",
+			"integrity": "sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==",
+			"peerDependencies": {
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/@emotion/utils": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.1.tgz",
+			"integrity": "sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg=="
+		},
+		"node_modules/@emotion/weak-memoize": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
+			"integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww=="
 		},
 		"node_modules/@esbuild/android-arm": {
 			"version": "0.16.17",
@@ -3147,6 +3277,237 @@
 				"@jridgewell/sourcemap-codec": "1.4.14"
 			}
 		},
+		"node_modules/@mui/base": {
+			"version": "5.0.0-beta.1",
+			"resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.1.tgz",
+			"integrity": "sha512-xrkDCeu3JQE+JjJUnJnOrdQJMXwKhbV4AW+FRjMIj5i9cHK3BAuatG/iqbf1M+jklVWLk0KdbgioKwK+03aYbA==",
+			"dependencies": {
+				"@babel/runtime": "^7.21.0",
+				"@emotion/is-prop-valid": "^1.2.0",
+				"@mui/types": "^7.2.4",
+				"@mui/utils": "^5.13.1",
+				"@popperjs/core": "^2.11.7",
+				"clsx": "^1.2.1",
+				"prop-types": "^15.8.1",
+				"react-is": "^18.2.0"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mui"
+			},
+			"peerDependencies": {
+				"@types/react": "^17.0.0 || ^18.0.0",
+				"react": "^17.0.0 || ^18.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@mui/base/node_modules/react-is": {
+			"version": "18.2.0",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+			"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+		},
+		"node_modules/@mui/core-downloads-tracker": {
+			"version": "5.13.1",
+			"resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.13.1.tgz",
+			"integrity": "sha512-qDHtNDO72NcBQMhaWBt9EZMvNiO+OXjPg5Sdk/6LgRDw6Zr3HdEZ5n2FJ/qtYsaT/okGyCuQavQkcZCOCEVf/g==",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mui"
+			}
+		},
+		"node_modules/@mui/material": {
+			"version": "5.13.1",
+			"resolved": "https://registry.npmjs.org/@mui/material/-/material-5.13.1.tgz",
+			"integrity": "sha512-qSnbJZer8lIuDYFDv19/t3s0AXYY9SxcOdhCnGvetRSfOG4gy3TkiFXNCdW5OLNveTieiMpOuv46eXUmE3ZA6A==",
+			"dependencies": {
+				"@babel/runtime": "^7.21.0",
+				"@mui/base": "5.0.0-beta.1",
+				"@mui/core-downloads-tracker": "^5.13.1",
+				"@mui/system": "^5.13.1",
+				"@mui/types": "^7.2.4",
+				"@mui/utils": "^5.13.1",
+				"@types/react-transition-group": "^4.4.6",
+				"clsx": "^1.2.1",
+				"csstype": "^3.1.2",
+				"prop-types": "^15.8.1",
+				"react-is": "^18.2.0",
+				"react-transition-group": "^4.4.5"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mui"
+			},
+			"peerDependencies": {
+				"@emotion/react": "^11.5.0",
+				"@emotion/styled": "^11.3.0",
+				"@types/react": "^17.0.0 || ^18.0.0",
+				"react": "^17.0.0 || ^18.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@emotion/react": {
+					"optional": true
+				},
+				"@emotion/styled": {
+					"optional": true
+				},
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@mui/material/node_modules/react-is": {
+			"version": "18.2.0",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+			"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+		},
+		"node_modules/@mui/private-theming": {
+			"version": "5.13.1",
+			"resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.13.1.tgz",
+			"integrity": "sha512-HW4npLUD9BAkVppOUZHeO1FOKUJWAwbpy0VQoGe3McUYTlck1HezGHQCfBQ5S/Nszi7EViqiimECVl9xi+/WjQ==",
+			"dependencies": {
+				"@babel/runtime": "^7.21.0",
+				"@mui/utils": "^5.13.1",
+				"prop-types": "^15.8.1"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mui"
+			},
+			"peerDependencies": {
+				"@types/react": "^17.0.0 || ^18.0.0",
+				"react": "^17.0.0 || ^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@mui/styled-engine": {
+			"version": "5.12.3",
+			"resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.12.3.tgz",
+			"integrity": "sha512-AhZtiRyT8Bjr7fufxE/mLS+QJ3LxwX1kghIcM2B2dvJzSSg9rnIuXDXM959QfUVIM3C8U4x3mgVoPFMQJvc4/g==",
+			"dependencies": {
+				"@babel/runtime": "^7.21.0",
+				"@emotion/cache": "^11.10.8",
+				"csstype": "^3.1.2",
+				"prop-types": "^15.8.1"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mui"
+			},
+			"peerDependencies": {
+				"@emotion/react": "^11.4.1",
+				"@emotion/styled": "^11.3.0",
+				"react": "^17.0.0 || ^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@emotion/react": {
+					"optional": true
+				},
+				"@emotion/styled": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@mui/system": {
+			"version": "5.13.1",
+			"resolved": "https://registry.npmjs.org/@mui/system/-/system-5.13.1.tgz",
+			"integrity": "sha512-BsDUjhiO6ZVAvzKhnWBHLZ5AtPJcdT+62VjnRLyA4isboqDKLg4fmYIZXq51yndg/soDK9RkY5lYZwEDku13Ow==",
+			"dependencies": {
+				"@babel/runtime": "^7.21.0",
+				"@mui/private-theming": "^5.13.1",
+				"@mui/styled-engine": "^5.12.3",
+				"@mui/types": "^7.2.4",
+				"@mui/utils": "^5.13.1",
+				"clsx": "^1.2.1",
+				"csstype": "^3.1.2",
+				"prop-types": "^15.8.1"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mui"
+			},
+			"peerDependencies": {
+				"@emotion/react": "^11.5.0",
+				"@emotion/styled": "^11.3.0",
+				"@types/react": "^17.0.0 || ^18.0.0",
+				"react": "^17.0.0 || ^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@emotion/react": {
+					"optional": true
+				},
+				"@emotion/styled": {
+					"optional": true
+				},
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@mui/types": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.4.tgz",
+			"integrity": "sha512-LBcwa8rN84bKF+f5sDyku42w1NTxaPgPyYKODsh01U1fVstTClbUoSA96oyRBnSNyEiAVjKm6Gwx9vjR+xyqHA==",
+			"peerDependencies": {
+				"@types/react": "*"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@mui/utils": {
+			"version": "5.13.1",
+			"resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.13.1.tgz",
+			"integrity": "sha512-6lXdWwmlUbEU2jUI8blw38Kt+3ly7xkmV9ljzY4Q20WhsJMWiNry9CX8M+TaP/HbtuyR8XKsdMgQW7h7MM3n3A==",
+			"dependencies": {
+				"@babel/runtime": "^7.21.0",
+				"@types/prop-types": "^15.7.5",
+				"@types/react-is": "^18.2.0",
+				"prop-types": "^15.8.1",
+				"react-is": "^18.2.0"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mui"
+			},
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0"
+			}
+		},
+		"node_modules/@mui/utils/node_modules/react-is": {
+			"version": "18.2.0",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+			"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+		},
 		"node_modules/@nabla/vite-plugin-eslint": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@nabla/vite-plugin-eslint/-/vite-plugin-eslint-1.5.0.tgz",
@@ -3225,6 +3586,15 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/@popperjs/core": {
+			"version": "2.11.7",
+			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
+			"integrity": "sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw==",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/popperjs"
 			}
 		},
 		"node_modules/@protobufjs/aspromise": {
@@ -3805,20 +4175,17 @@
 		"node_modules/@types/parse-json": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
-			"dev": true
+			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
 		},
 		"node_modules/@types/prop-types": {
 			"version": "15.7.5",
 			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-			"integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-			"dev": true
+			"integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
 		},
 		"node_modules/@types/react": {
 			"version": "18.0.28",
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.28.tgz",
 			"integrity": "sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==",
-			"dev": true,
 			"dependencies": {
 				"@types/prop-types": "*",
 				"@types/scheduler": "*",
@@ -3830,6 +4197,22 @@
 			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz",
 			"integrity": "sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==",
 			"dev": true,
+			"dependencies": {
+				"@types/react": "*"
+			}
+		},
+		"node_modules/@types/react-is": {
+			"version": "18.2.0",
+			"resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-18.2.0.tgz",
+			"integrity": "sha512-1vz2yObaQkLL7YFe/pme2cpvDsCwI1WXIfL+5eLz0MI9gFG24Re16RzUsI8t9XZn9ZWvgLNDrJBmrqXJO7GNQQ==",
+			"dependencies": {
+				"@types/react": "*"
+			}
+		},
+		"node_modules/@types/react-transition-group": {
+			"version": "4.4.6",
+			"resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.6.tgz",
+			"integrity": "sha512-VnCdSxfcm08KjsJVQcfBmhEQAPnLB8G08hAxn39azX1qYBQ/5RVQuoHuKIcfKOdncuaUvEpFKFzEvbtIMsfVew==",
 			"dependencies": {
 				"@types/react": "*"
 			}
@@ -3846,8 +4229,7 @@
 		"node_modules/@types/scheduler": {
 			"version": "0.16.2",
 			"resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-			"integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-			"dev": true
+			"integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
 		},
 		"node_modules/@types/semver": {
 			"version": "7.3.13",
@@ -4617,7 +4999,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
 			"integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.12.5",
 				"cosmiconfig": "^7.0.0",
@@ -4797,7 +5178,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-			"dev": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -4961,6 +5341,14 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/clsx": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+			"integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -5028,8 +5416,7 @@
 		"node_modules/convert-source-map": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-			"integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-			"dev": true
+			"integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
 		},
 		"node_modules/core-js-compat": {
 			"version": "3.29.1",
@@ -5048,7 +5435,6 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
 			"integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-			"dev": true,
 			"dependencies": {
 				"@types/parse-json": "^4.0.0",
 				"import-fresh": "^3.2.1",
@@ -5102,10 +5488,9 @@
 			}
 		},
 		"node_modules/csstype": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-			"integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
-			"dev": true
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+			"integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
 		},
 		"node_modules/damerau-levenshtein": {
 			"version": "1.0.8",
@@ -5278,6 +5663,15 @@
 			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
 			"dev": true
 		},
+		"node_modules/dom-helpers": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+			"integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+			"dependencies": {
+				"@babel/runtime": "^7.8.7",
+				"csstype": "^3.0.2"
+			}
+		},
 		"node_modules/domexception": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
@@ -5339,7 +5733,6 @@
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
 			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-			"dev": true,
 			"dependencies": {
 				"is-arrayish": "^0.2.1"
 			}
@@ -5501,7 +5894,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
 			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-			"dev": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -6219,6 +6611,11 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/find-root": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+			"integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+		},
 		"node_modules/find-up": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -6357,8 +6754,7 @@
 		"node_modules/function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
 		},
 		"node_modules/function.prototype.name": {
 			"version": "1.1.5",
@@ -6565,7 +6961,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
 			"dependencies": {
 				"function-bind": "^1.1.1"
 			},
@@ -6641,6 +7036,19 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/hoist-non-react-statics": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+			"integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+			"dependencies": {
+				"react-is": "^16.7.0"
+			}
+		},
+		"node_modules/hoist-non-react-statics/node_modules/react-is": {
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
 		"node_modules/html-encoding-sniffer": {
 			"version": "3.0.0",
@@ -6740,7 +7148,6 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
 			"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-			"dev": true,
 			"dependencies": {
 				"parent-module": "^1.0.0",
 				"resolve-from": "^4.0.0"
@@ -6833,8 +7240,7 @@
 		"node_modules/is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-			"dev": true
+			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
 		},
 		"node_modules/is-bigint": {
 			"version": "1.0.4",
@@ -6880,7 +7286,6 @@
 			"version": "2.11.0",
 			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
 			"integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
-			"dev": true,
 			"dependencies": {
 				"has": "^1.0.3"
 			},
@@ -7455,8 +7860,7 @@
 		"node_modules/json-parse-even-better-errors": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-			"dev": true
+			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
 		},
 		"node_modules/json-schema": {
 			"version": "0.4.0",
@@ -7586,8 +7990,7 @@
 		"node_modules/lines-and-columns": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-			"dev": true
+			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
 		},
 		"node_modules/lint-staged": {
 			"version": "13.2.0",
@@ -8138,7 +8541,6 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -8346,7 +8748,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
 			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-			"dev": true,
 			"dependencies": {
 				"callsites": "^3.0.0"
 			},
@@ -8358,7 +8759,6 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
 			"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.0.0",
 				"error-ex": "^1.3.1",
@@ -8414,14 +8814,12 @@
 		"node_modules/path-parse": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-			"dev": true
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
 		},
 		"node_modules/path-type": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
 			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -8572,7 +8970,6 @@
 			"version": "15.8.1",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
 			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-			"dev": true,
 			"dependencies": {
 				"loose-envify": "^1.4.0",
 				"object-assign": "^4.1.1",
@@ -8582,8 +8979,7 @@
 		"node_modules/prop-types/node_modules/react-is": {
 			"version": "16.13.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-			"dev": true
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
 		"node_modules/protobufjs": {
 			"version": "6.11.3",
@@ -8728,6 +9124,21 @@
 				"react-dom": ">=16.8"
 			}
 		},
+		"node_modules/react-transition-group": {
+			"version": "4.4.5",
+			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+			"integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+			"dependencies": {
+				"@babel/runtime": "^7.5.5",
+				"dom-helpers": "^5.0.1",
+				"loose-envify": "^1.4.0",
+				"prop-types": "^15.6.2"
+			},
+			"peerDependencies": {
+				"react": ">=16.6.0",
+				"react-dom": ">=16.6.0"
+			}
+		},
 		"node_modules/redent": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -8762,8 +9173,7 @@
 		"node_modules/regenerator-runtime": {
 			"version": "0.13.11",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-			"dev": true
+			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
 		},
 		"node_modules/regenerator-transform": {
 			"version": "0.15.1",
@@ -8856,7 +9266,6 @@
 			"version": "1.22.1",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
 			"integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
-			"dev": true,
 			"dependencies": {
 				"is-core-module": "^2.9.0",
 				"path-parse": "^1.0.7",
@@ -8873,7 +9282,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -9455,6 +9863,11 @@
 				"url": "https://github.com/sponsors/antfu"
 			}
 		},
+		"node_modules/stylis": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+			"integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
+		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -9471,7 +9884,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
 			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -9606,7 +10018,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
 			"integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -10750,7 +11161,6 @@
 			"version": "1.10.2",
 			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
 			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-			"dev": true,
 			"engines": {
 				"node": ">= 6"
 			}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
 		"npm": ">=8.19.0"
 	},
 	"dependencies": {
+		"@emotion/react": "^11.11.0",
+		"@emotion/styled": "^11.11.0",
+		"@mui/material": "^5.13.1",
 		"@the-collab-lab/shopping-list-utils": "^2.0.0",
 		"firebase": "^9.17.2",
 		"react": "^18.2.0",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,7 +1,7 @@
 import { createRoot } from 'react-dom/client';
 import { App } from './App';
 
-import './index.css';
+// import './index.css';
 
 const root = createRoot(document.getElementById('root'));
 root.render(<App />);

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -1,4 +1,5 @@
 import { Navigate } from 'react-router-dom';
+import { Button } from '@mui/material';
 import './Home.css';
 import { generateToken } from '@the-collab-lab/shopping-list-utils';
 import { useState } from 'react';
@@ -39,9 +40,14 @@ export function Home({ setListToken }) {
 				You can create a new shopping list, or type in a token to view an
 				existing list.
 			</h3>
-			<button type="button" onClick={handleClick}>
+			<Button
+				type="button"
+				variant="contained"
+				size="large"
+				onClick={handleClick}
+			>
 				Create new list
-			</button>
+			</Button>
 			<p> - or - </p>
 			<form onSubmit={handleSumbit}>
 				<label htmlFor="tokenInput">Three word token:</label>

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -1,6 +1,6 @@
 import { NavLink, Outlet } from 'react-router-dom';
 
-import './Layout.css';
+// import './Layout.css';
 
 /**
  * TODO: The links defined in this file don't work!


### PR DESCRIPTION
## Description

This PR removes the use of (but does not delete) the CSS inherited from the boilerplate code. It also installs packages from the MUI component library and replaces a button on the Home page with an MUI primary button.

## Related Issue
This falls under the umbrella of #13, but does not close it.

## Acceptance Criteria

The AC for this issue were developed on the fly during a team meeting:
- [x] install the MUI component library packages
- [x] import an MUI component into the app and render it
- [x] stop using the CSS styles we inherited from the project boilerplate

## Type of Changes

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

| Before  (macOS, Edge, dark mode)                                                                                              	| After (macOS, Edge, dark mode)                                                                                                 	|
|-------------------------------------------------------------------------------------------------------	|-------------------------------------------------------------------------------------------------------	|
| <img width="551" alt="CleanShot 2023-05-18 at 15 27 51@2x" src="https://github.com/the-collab-lab/tcl-57-smart-shopping-list/assets/13525251/5942f7cf-d8c9-42da-a81f-b7aa4ae37a41"> 	| <img width="627" alt="CleanShot 2023-05-18 at 15 27 16@2x" src="https://github.com/the-collab-lab/tcl-57-smart-shopping-list/assets/13525251/72f178f5-6e0e-4f5d-9f58-196304b030fd"> 	|

## Testing Steps / QA Criteria

Verify that the new button looks good, and everything else is expectedly hideous!
