### PR TITLE
Fix height of container in List page.

### DIFF
--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -16,6 +16,7 @@ import {
 	DialogContent,
 	DialogContentText,
 	Slide,
+	Box,
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 import AddIcon from '@mui/icons-material/Add';
@@ -86,7 +87,7 @@ export function List({ data, listToken }) {
 	}
 
 	return (
-		<>
+		<Box minHeight="100vh">
 			{listIsEmpty ? (
 				<>
 					<Typography variant="h2">Your list is currently empty.</Typography>
@@ -166,6 +167,6 @@ export function List({ data, listToken }) {
 					<Button onClick={handleCloseDialog}>Cancel</Button>
 				</DialogActions>
 			</Dialog>
-		</>
+		</Box>
 	);
 }


### PR DESCRIPTION
## Description

<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? Reminder: This will be a publicly facing representation of your work (READ: help you land that sweet dev gig). -->

The List page did not extend to the height of the viewport when the user's list did not fill the entire screen (when their list was empty or when their list was short). 

## Related Issue
<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->
Closes #42 

## Acceptance Criteria
<!-- Include AC from the Github issue -->
- [x] List page container extends to the height of the viewport even when its content does not fill the screen.

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
| ✓   | :bug: Bug fix              |
|     | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before
<img width="1072" alt="3" src="https://github.com/the-collab-lab/tcl-57-smart-shopping-list/assets/9102330/f3ab884a-bab2-43b6-9999-2899296da34b">

<img width="1028" alt="4" src="https://github.com/the-collab-lab/tcl-57-smart-shopping-list/assets/9102330/11f50514-70c3-481b-b223-cad67b28c67e">



### After
<img width="1072" alt="1" src="https://github.com/the-collab-lab/tcl-57-smart-shopping-list/assets/9102330/598751b0-529e-48a8-80d1-7ec8624c9019">

<img width="1072" alt="2" src="https://github.com/the-collab-lab/tcl-57-smart-shopping-list/assets/9102330/80b80347-5047-40bd-9808-e311790783c7">
## Testing Steps / QA Criteria

<!-- Provide steps the other cohort members and mentors need to follow to properly test your additions. -->
