### PR TITLE
Style "empty list" page on `List` view

### DIFF
--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -93,7 +93,7 @@ export function List({ data, listToken }) {
 		<Box minHeight="100vh">
 			{listIsEmpty ? (
 				<Box display="flex" flexDirection="column">
-					<Typography variant="h6" paddingTop="75px" paddingBottom="50px">
+					<Typography variant="h2" paddingTop="75px" paddingBottom="50px">
 						Your list is currently empty.
 					</Typography>
 					{/* <Typography variant="body2">

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -16,6 +16,7 @@ import {
 	DialogContent,
 	DialogContentText,
 	Slide,
+	Box,
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 import AddIcon from '@mui/icons-material/Add';
@@ -88,11 +89,13 @@ export function List({ data, listToken }) {
 	return (
 		<>
 			{listIsEmpty ? (
-				<>
-					<Typography variant="h2">Your list is currently empty.</Typography>
-					<Typography variant="h3">
-						Add your first item by clicking the button below.
+				<Box display="flex" flexDirection="column" minHeight="100vh">
+					<Typography variant="h6" paddingTop="75px" paddingBottom="50px">
+						Your list is currently empty.
 					</Typography>
+					{/* <Typography variant="body2">
+						Add your first item by clicking the button below.
+					</Typography> */}
 					<Button
 						type="button"
 						variant="contained"
@@ -102,7 +105,7 @@ export function List({ data, listToken }) {
 					>
 						Add first item
 					</Button>
-				</>
+				</Box>
 			) : (
 				<>
 					<Container

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -89,7 +89,7 @@ export function List({ data, listToken }) {
 	return (
 		<Box minHeight="100vh">
 			{listIsEmpty ? (
-				<Box display="flex" flexDirection="column" minHeight="100vh">
+				<Box display="flex" flexDirection="column">
 					<Typography variant="h6" paddingTop="75px" paddingBottom="50px">
 						Your list is currently empty.
 					</Typography>


### PR DESCRIPTION
## Description
This PR cleans up the empty list message that displays on the `List` view when the user's list is empty.

## Related Issue
Closes #40

## Acceptance Criteria

- [x]  Smaller font sizes
- [x]  Fix centering spacing, margins, etc.

## Type of Changes
|     | Type                       |
| --- | -------------------------- |
| ✓   | :bug: Bug fix              |
|   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before
![image](https://github.com/the-collab-lab/tcl-57-smart-shopping-list/assets/84364905/d4c12c13-248a-439d-95de-dfcf252e7aab)

### After
<img width="1423" alt="Screenshot 2023-05-26 at 3 10 50 PM" src="https://github.com/the-collab-lab/tcl-57-smart-shopping-list/assets/84364905/e0b31919-0dab-49f8-96a0-58dcbab322d9">

## Testing Steps / QA Criteria
- visit preview URL: https://tcl-57-smart-shopping-list--pr52-es-style-empty-list-klmrhlt6.web.app/
- create a new list and on the `List` view, ensure that the empty list message typography and styling is clean and consistent with the other pages of the app
